### PR TITLE
Fixing the problem when file extension is missing when saving

### DIFF
--- a/android/src/main/kotlin/com/deepanshuchaudhary/pick_or_save/Save.kt
+++ b/android/src/main/kotlin/com/deepanshuchaudhary/pick_or_save/Save.kt
@@ -107,7 +107,7 @@ fun saveSingleFile(
     }
 
     val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
-    intent.putExtra(Intent.EXTRA_TITLE, saveFileNamePrefix)
+    intent.putExtra(Intent.EXTRA_TITLE, saveFileName)
     if (localOnly) {
         intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true)
     }


### PR DESCRIPTION
I encountered the same problem as here https://github.com/chaudharydeepanshu/pick_or_save/issues/3, and I tweaked the code a bit.
