### PR TITLE
:ambulance: Unable plugin usage on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
         namespace 'com.deepanshuchaudhary.pick_or_save'
     }
 
-    compileSdkVersion 34
+    compileSdk 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
- Updated `compileSdkVersion` to `compileSdk` as it's deprecated from AGP version after 7.0.0 (https://developer.android.com/reference/tools/gradle-api/8.2/com/android/build/api/dsl/CommonExtension#compileSdkVersion(kotlin.Int))