### PR TITLE
Update to fulfill 16 KB Google Play compatibility requirement

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
         namespace 'com.deepanshuchaudhary.pick_or_save'
     }
 
-    compileSdk 34
+    compileSdk 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -46,7 +46,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 36
     }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
     namespace "com.deepanshuchaudhary.pick_or_save_example"
 
     defaultConfig {
-        compileSdk 34
+        compileSdk 36
     }
 
     ndkVersion flutter.ndkVersion
@@ -50,7 +50,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/chaudharydeepanshu/pick_or_save
 issue_tracker: https://github.com/chaudharydeepanshu/pick_or_save/issues
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'
   flutter: ">=2.5.0"
 
 dependencies:


### PR DESCRIPTION
Increase targetSdkVersion and compileSdk to be able to build apps which support 16 KB Google Play compatibility requirement.

https://developer.android.com/guide/practices/page-sizes?hl=en
https://developer.android.com/tools/releases/platforms?hl=en